### PR TITLE
Release 1.11.4

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -3,8 +3,10 @@ name: Android CI
 on:
   push:
     branches:
-      - '*'
+      - 'dev'
   pull_request:
+    branches-ignore:
+      - 'dev'
 
 jobs:
   build:
@@ -22,6 +24,9 @@ jobs:
       with:
         go-version: 1.14
       id: go
+    # https://github.com/actions/virtual-environments/issues/578
+    - name: Fix missing NDK dependency
+      run: echo "y" | sudo ${ANDROID_HOME}/tools/bin/sdkmanager --install "ndk;20.0.5594570"
     - name: Build rclone
       run: ./gradlew buildNative -p rclone
     - name: Build app

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -99,7 +99,7 @@ dependencies {
     implementation 'androidx.preference:preference:1.1.0'
     implementation 'com.google.android.material:material:1.0.0'
     implementation 'com.leinardi.android:speed-dial:2.0.0'
-    implementation 'us.feras.mdv:markdownview:1.1.0'
+    implementation 'org.markdownj:markdownj-core:0.4'
     implementation 'jp.wasabeef:recyclerview-animators:2.3.0'
     implementation 'com.github.GrenderG:Toasty:1.3.0'
     // Firebase & Crashlytics

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,8 +15,8 @@ android {
         applicationId 'io.github.x0b.rcx'
         minSdkVersion 21
         targetSdkVersion 29
-        versionCode 160 // last digit is reserved for ABI, only ever end on 0!
-        versionName '1.11.3'
+        versionCode 170 // last digit is reserved for ABI, only ever end on 0!
+        versionName '1.11.4'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/assets/changelog.md
+++ b/app/src/main/assets/changelog.md
@@ -1,3 +1,14 @@
+### 1.11.4
+* **Fix:** Crash when sharing file to rcx contains garbage data, part II
+* **Fix:** Crash when deleting remotes
+* **Fix:** Crash when opening changelog or license on Android Lollipop. Note that Lollipop is no longer supported and will be removed in a future version. 
+* **Fix:** Crash when generating link
+* **Fix:** VLC not playing audio files
+* **Fix:** Link, Sync and Download being displayed for local remotes
+* **Fix:** RCX not working on some 64 Bit ARM devices. This might break again in a future version.
+
+***
+
 ### 1.11.3
 * **Fix:** Crash when selecting "Add Storage" on TVs and other devices
 * **Fix:** Crash when sharing file to rcx contains garbage data
@@ -125,153 +136,7 @@
 * First Release with non-conflicting package name
 * **New:** Update to Rclone v1.49.1
 * **New:** Support for devices with x86_64 cpu and new Android W^X policy
-* **New:** Import external config files automatically by placing them on external storage in ```Android/data/ca.pkay.rcloneexplorer.x0b/files/rclone.conf```
+* **New:** Import external config files automatically by placing them on external storage in ```Android/data/``````ca.pkay.rcloneexplorer.x0b``````/files/rclone.conf```
 * **New:** Fix files with mime type application/octet-stream if they have a playable extension
 * **Fix:** Crash when folder to large
 * **Fix:** Onedrive config has been removed from ui because it is no longer compatible with rclone
-
-***
-
-### 1.7.4
-* Update to Rclone v1.44
-* **New:** Support for Android 9
-* **New:** Serve feature
-    * Support FTP
-    * Remote access (off by default)
-    * Optional authentication
-* **Fix:** Crash when external SD card isn't mounted
-
-***
-
-### 1.7.3
-* **Fix:** FAB appearing when bottom bar is visible
-* **New:** Get notified when beta releases are available
-    * Enable in Settings under Notifications (stable update notifications must be enabled)
-
-***
-
-### 1.7.2
-* **New:** Option to hide remotes
-* **Fix:** Upload bug in serve webdav
-* **Fix:** Missing transfer status missing from notification
-
-***
-
-### 1.7.1
-* **New:** Redesign settings layout
-* **Update:** Libraries
-* **Fix:** Some bugs with pinned navigation drawer remotes
-* **Fix:** Crash when sharing files with the app
-* **Fix:** Some other crashes
-
-***
-
-### 1.7.0
-* **New:** Show progress in upload, download, and sync notifications
-* **New:** Pin remotes to navigation drawer
-* **New:** Option to limit transfers to Wi-Fi only
-* **New:** Sync
-* **New:** Add sync webdev
-* **New:** When downloading, uploading, syncing, transfer only one file in parallel
-* **New:** Make crash reports and app update notifications optional
-* **New:** Update some icons
-* **Fix:** Proper encoding of URLs for streaming
-* **Fix:** Crashes
-
-***
-
-### 1.6.0
-* **New:** Allow setting which remotes are in app shortcuts (from settings)
-* **New:** Pin remotes on supported launchers (Android 8.0)
-    * From the remotes screen, press the options button for a remote and click 'Add to home screen'
-* **New:** Show cancel button in toolbar when items selected or in move mode
-* **New:** Download files to SD card
-* **New:** Upload files from SD card
-* **New:** Confirmation before emptying trash
-* **Fix:** Handle screen orientation change when selecting files for upload
-
-***
-
-### 1.5.0
-* **New:** Add support for local remotes
-* **New:** Add option to create Google Drive remotes
-* **New:** Show detailed modified time in properties dialog
-* **Fix:** Hide directory modified time in propertied dialog for unsupported remotes
-* **Fix:** App update notification click action not working
-* **Fix:** Consider app version name when checking if app was updated
-* **Fix:** Videos and music files not streaming from crypt remote
-* **Fix:** Thumbnails being wrong in some circumstances
-
-***
-
-### 1.4.0
-* **New:** Update to Rclone v1.42
-* **New:** Use MimeType supplied by Rclone v1.42
-* **New:** Option to show full file names
-* **New:** Allow screen rotation with files selected
-* **New:** Allow screen rotation when moving files
-* **New:** Option to create new folders when downloading files
-* **New:** Scroll to previous directory when going back
-* **New:** Option to specify Root or Home as starting point for SFTP/SSH
-* **New:** Go to starting directory when cancelling file move
-* **Fix:** Light Blue not getting selected as primary color
-* **Fix:** Wrong password getting set from password generator
-* **Fix:** New folders not getting created from Remote Destination Dialog
-* **Fix:** Crash reporting
-* **Fix:** Files not getting sorted in local file picker
-* **Fix:** Crash when downloading files
-* **Fix:** Load thumbnails for pictures and videos only (reduces app data usage)
-* **Fix:** FAB getting stuck in hidden position
-* **Fix:** Hide some menu options when files are selected
-
-***
-
-### 1.3.6
-* This update contains mostly bug fixes
-* **Fix:** Crash in dialogs on screen orientation change
-* **Fix:** Displayed mod time
-* **Fix:** Yandex remote creation
-* **Fix:** Azure remote creation
-* **Fix:** Hide directory mod time for remotes that don't support it
-* **Fix:** Error notification after successful move
-
-***
-
-### 1.3.5
-* **New:** Show file thumbnails (experimental feature, enable in settings)
-* **New:** App updates notification updates
-    * Open the GitHub releases page on notification click
-    * Show app icon
-* **New:** Option to cancel delete and move operations
-* **New:** Password generator for crypt remote creation
-* **Fix:** Delete button now working
-* **Fix:** Displayed modification time
-* **Fix:** Possible crash when loading remotes
-
-***
-
-### 1.3.4
-* **New:** Add option to pin remotes to the top
-* **Fix:** Possible crash when loading remotes
-* **Fix:** Remove dynamic shortcut when a remote is deleted
-
-***
-
-### 1.3.3
-* **Fix:** Infinite loading for directories with large number of files
-* **Fix:** Open as not working
-* **Fix:** App launching behaviour
-* **Fix:** Theme of password dialog
-
-***
-
-### 1.3.2
-* **New:** File options for individual files
-* **New:** Generate public link to file/folder (rclone link)
-* **New:** Support cache remotes
-* **New:** Support cache remote creation
-* **New:** Make anonymous crash reporting optional
-* **Fix:** Sort remotes
-* **Fix:** Refreshing while in search mode
-* **Fix:** Detect remote type of alias/crypt remotes to show/hide specific options
-* **Update:** Hint and helper text for salt in crypt config

--- a/app/src/main/java/ca/pkay/rcloneexplorer/ChangelogActivity.java
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/ChangelogActivity.java
@@ -5,8 +5,7 @@ import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
 
-import us.feras.mdv.MarkdownView;
-
+import ca.pkay.rcloneexplorer.util.MarkdownView;
 
 public class ChangelogActivity extends AppCompatActivity {
 
@@ -24,7 +23,7 @@ public class ChangelogActivity extends AppCompatActivity {
         }
 
         MarkdownView markdownView = findViewById(R.id.markdownView);
-        markdownView.loadMarkdownFile("file:///android_asset/changelog.md");
+        markdownView.loadAsset("changelog.md");
     }
 
     @Override

--- a/app/src/main/java/ca/pkay/rcloneexplorer/ContributorActivity.java
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/ContributorActivity.java
@@ -4,7 +4,7 @@ import android.os.Bundle;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
-import us.feras.mdv.MarkdownView;
+import ca.pkay.rcloneexplorer.util.MarkdownView;
 
 
 public class ContributorActivity extends AppCompatActivity {
@@ -23,7 +23,7 @@ public class ContributorActivity extends AppCompatActivity {
         }
 
         MarkdownView markdownView = findViewById(R.id.markdownView);
-        markdownView.loadMarkdownFile("file:///android_asset/contributors.md");
+        markdownView.loadAsset("contributors.md");
     }
 
     @Override

--- a/app/src/main/java/ca/pkay/rcloneexplorer/Fragments/FileExplorerFragment.java
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/Fragments/FileExplorerFragment.java
@@ -1691,7 +1691,7 @@ public class FileExplorerFragment extends Fragment implements   FileExplorerRecy
             }
         }
     }
-    
+
     @SuppressLint("StaticFieldLeak")
     private class RenameFileTask extends AsyncTask<String, Void, Boolean> {
 

--- a/app/src/main/java/ca/pkay/rcloneexplorer/Fragments/FileExplorerFragment.java
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/Fragments/FileExplorerFragment.java
@@ -571,12 +571,16 @@ public class FileExplorerFragment extends Fragment implements   FileExplorerRecy
         if (!remote.hasTrashCan()) {
             menu.findItem(R.id.action_empty_trash).setVisible(false);
         }
-        if (remote.isCrypt()) {
+        if (!remote.hasLinkSupport()) {
             menu.findItem(R.id.action_link).setVisible(false);
         }
         if (!remote.isRemoteType(RemoteItem.SFTP)) {
             menu.findItem(R.id.action_go_to).setVisible(false);
         }
+        if (!remote.hasSyncSupport()) {
+            menu.findItem(R.id.action_sync).setVisible(false);
+        }
+
         menu.findItem(R.id.action_wrap_filenames).setChecked(true);
 
         if (isInMoveMode || recyclerViewAdapter.isInSelectMode()) {
@@ -1351,11 +1355,16 @@ public class FileExplorerFragment extends Fragment implements   FileExplorerRecy
         } else {
             popupMenu.getMenu().findItem(R.id.action_sync).setVisible(false);
         }
-        if (remote.isCrypt()) {
+        if (!remote.hasSyncSupport()) {
+            // TODO: remove once destination sync is added.
+            popupMenu.getMenu().findItem(R.id.action_sync).setVisible(false);
+        }
+        if (!remote.hasLinkSupport()) {
             popupMenu.getMenu().findItem(R.id.action_link).setVisible(false);
         }
-        if (remote.isCrypt()) {
-            popupMenu.getMenu().findItem(R.id.action_link).setVisible(false);
+        if (remote.isRemoteType(RemoteItem.LOCAL, RemoteItem.SAFW) || remote.isPathAlias()) {
+            // TODO: replace with .setTitle(copy) once destination copy is added
+            popupMenu.getMenu().findItem(R.id.action_download).setVisible(false);
         }
     }
 

--- a/app/src/main/java/ca/pkay/rcloneexplorer/Fragments/FileExplorerFragment.java
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/Fragments/FileExplorerFragment.java
@@ -2089,7 +2089,7 @@ public class FileExplorerFragment extends Fragment implements   FileExplorerRecy
             LinkDialog linkDialog = new LinkDialog()
                     .isDarkTheme(isDarkTheme)
                     .setLinkUrl(s);
-            if (getFragmentManager() != null) {
+            if (getFragmentManager() != null && !getChildFragmentManager().isStateSaved()) {
                 linkDialog.show(getChildFragmentManager(), "link dialog");
             }
 

--- a/app/src/main/java/ca/pkay/rcloneexplorer/Fragments/FileExplorerFragment.java
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/Fragments/FileExplorerFragment.java
@@ -1,6 +1,7 @@
 package ca.pkay.rcloneexplorer.Fragments;
 
 import android.annotation.SuppressLint;
+import android.app.Activity;
 import android.content.BroadcastReceiver;
 import android.content.ClipData;
 import android.content.ClipboardManager;
@@ -1974,8 +1975,7 @@ public class FileExplorerFragment extends Fragment implements   FileExplorerRecy
             boolean available = false;
             while (retries > 0) {
                 try {
-                    URL checkUrl = new URL(uri.toString());
-                    FLog.v(TAG, "doInBackground: GET %s", checkUrl.toString());
+                    FLog.v(TAG, "doInBackground: HEAD %s", uri.toString());
                     Response response = client.newCall(request).execute();
                     code = response.code();
 
@@ -2021,7 +2021,11 @@ public class FileExplorerFragment extends Fragment implements   FileExplorerRecy
             }
             Dialogs.dismissSilently(loadingDialog);
             if(success) {
-                tryStartActivityForResult(FileExplorerFragment.this, intent, STREAMING_INTENT_RESULT);
+                Activity activity = getActivity();
+                if (null == activity) {
+                    return;
+                }
+                tryStartActivityForResult(activity, intent, STREAMING_INTENT_RESULT);
             } else {
                 Toasty.error(context, getString(R.string.streaming_task_failed), Toast.LENGTH_LONG, true).show();
                 context.stopService(serveIntent);

--- a/app/src/main/java/ca/pkay/rcloneexplorer/Fragments/RemotesFragment.java
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/Fragments/RemotesFragment.java
@@ -197,7 +197,7 @@ public class RemotesFragment extends Fragment implements RemotesRecyclerViewAdap
     }
 
     private void refreshFragment() {
-        if (getFragmentManager() == null) {
+        if (getFragmentManager() == null || isStateSaved()) {
             return;
         }
 
@@ -501,17 +501,19 @@ public class RemotesFragment extends Fragment implements RemotesRecyclerViewAdap
         builder.setTitle(R.string.delete_remote_title);
         builder.setMessage(remoteItem.getDisplayName());
         builder.setNegativeButton(R.string.cancel, null);
-        builder.setPositiveButton(R.string.delete, (dialog, which) -> new DeleteRemote(remoteItem).execute());
+        builder.setPositiveButton(R.string.delete, (dialog, which) -> new DeleteRemote(context, remoteItem).execute());
         builder.show();
     }
 
     @SuppressLint("StaticFieldLeak")
     private class DeleteRemote extends AsyncTask<Void, Void, Void> {
 
-        private RemoteItem remoteItem;
+        private final RemoteItem remoteItem;
+        private final Context context;
 
-        DeleteRemote(RemoteItem remoteItem) {
+        public DeleteRemote(Context context, RemoteItem remoteItem) {
             this.remoteItem = remoteItem;
+            this.context = context.getApplicationContext();
         }
 
         @Override

--- a/app/src/main/java/ca/pkay/rcloneexplorer/Items/RemoteItem.java
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/Items/RemoteItem.java
@@ -150,6 +150,21 @@ public class RemoteItem implements Comparable<RemoteItem>, Parcelable {
         }
     }
 
+    public boolean hasLinkSupport(){
+        if (isRemoteType(CRYPT, LOCAL, SAFW) || isPathAlias) {
+            return false;
+        }
+        return true;
+    }
+
+    // TODO: check callers once destination sync is added
+    public boolean hasSyncSupport() {
+        if (isRemoteType(LOCAL, SAFW) || isPathAlias) {
+            return false;
+        }
+        return true;
+    }
+
     public String getName() {
         return name;
     }

--- a/app/src/main/java/ca/pkay/rcloneexplorer/SharingActivity.java
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/SharingActivity.java
@@ -220,7 +220,7 @@ public class SharingActivity extends AppCompatActivity implements   ShareRemotes
             boolean success = true;
             for (Uri uri : uris) {
                 String fileName;
-                if (null == uri.getScheme() || null == uri.getPath()) {
+                if (null == uri || null == uri.getScheme() || null == uri.getPath()) {
                     FLog.w(TAG, "Can't copy invalid uri %s", uri);
                     success = false;
                     continue;

--- a/app/src/main/java/ca/pkay/rcloneexplorer/util/MarkdownView.java
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/util/MarkdownView.java
@@ -1,0 +1,78 @@
+package ca.pkay.rcloneexplorer.util;
+
+import android.content.Context;
+import android.content.res.AssetManager;
+import android.content.res.Configuration;
+import android.os.AsyncTask;
+import android.os.Build;
+import android.util.AttributeSet;
+import android.webkit.WebView;
+import org.markdownj.MarkdownProcessor;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class MarkdownView extends WebView {
+
+    public MarkdownView(Context context) {
+        super(patchContext(context));
+    }
+
+    public MarkdownView(Context context, AttributeSet attrs) {
+        super(patchContext(context), attrs);
+    }
+
+    private static Context patchContext(Context context) {
+        // TODO: Only affects appcompat 1.1.x, remove with 1.2.x
+        //       https://stackoverflow.com/questions/41025200/android-view-inflateexception-error-inflating-class-android-webkit-webview/58131421
+        if (Build.VERSION.SDK_INT == 22 || Build.VERSION.SDK_INT == 23) {
+            return context.createConfigurationContext(new Configuration());
+        }
+        return context;
+    }
+
+    public void loadAsset(String path) {
+        new LoadMarkdownAsset(path, this).execute();
+    }
+
+    private static class LoadMarkdownAsset extends AsyncTask<Void, Void, String> {
+
+        private static final String TAG = "LoadMarkdownAsset";
+        private final String assetName;
+        private final WebView webView;
+
+        public LoadMarkdownAsset(String assetName, WebView webView) {
+            this.assetName = assetName;
+            this.webView = webView;
+        }
+
+        @Override
+        protected String doInBackground(Void... voids) {
+            Context context = webView.getContext();
+            AssetManager assetManager = context.getAssets();
+            try (BufferedReader br = new BufferedReader(new InputStreamReader(assetManager.open(assetName)))) {
+                StringBuilder markdown = new StringBuilder(4096);
+                String line;
+                while ((line = br.readLine()) != null) {
+                    // Use \n as line seperator so that the processor does not
+                    // have to replace this.
+                    markdown.append(line).append('\n');
+                }
+                return new MarkdownProcessor().markdown(markdown.toString());
+            } catch (IOException e) {
+                FLog.e(TAG, "Could not load asset ", e);
+            }
+            return null;
+        }
+
+        @Override
+        protected void onPostExecute(String html) {
+            if (null == html) {
+                webView.loadUrl("about:blank");
+            } else {
+                webView.loadDataWithBaseURL("local://", html, "text/html", "UTF-8", null);
+            }
+        }
+    }
+}

--- a/app/src/main/res/layout/content_changelog.xml
+++ b/app/src/main/res/layout/content_changelog.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<us.feras.mdv.MarkdownView
+<ca.pkay.rcloneexplorer.util.MarkdownView
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
@@ -9,4 +9,4 @@
     app:layout_behavior="@string/appbar_scrolling_view_behavior"
     tools:context=".AboutActivity"
     tools:showIn="@layout/activity_about" >
-</us.feras.mdv.MarkdownView>
+</ca.pkay.rcloneexplorer.util.MarkdownView>

--- a/app/src/main/res/layout/content_contributors.xml
+++ b/app/src/main/res/layout/content_contributors.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<us.feras.mdv.MarkdownView
+<ca.pkay.rcloneexplorer.util.MarkdownView
         xmlns:android="http://schemas.android.com/apk/res/android"
         xmlns:app="http://schemas.android.com/apk/res-auto"
         xmlns:tools="http://schemas.android.com/tools"
@@ -9,4 +9,4 @@
         app:layout_behavior="@string/appbar_scrolling_view_behavior"
         tools:context=".ContributorActivity"
         tools:showIn="@layout/activity_contributors" >
-</us.feras.mdv.MarkdownView>
+</ca.pkay.rcloneexplorer.util.MarkdownView>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -422,7 +422,7 @@
     <string name="select_remotes_to_hide">Select remotes to hide</string>
     <string name="pref_key_renamed_remotes" translatable="false">renamed_remotes</string>
     <string name="pref_key_renamed_remote_prefix" translatable="false">remote_name_%1$s</string>
-    <string name="allow_remote_access">Allow remote access</string>
+    <string name="allow_remote_access">Allow access from other devices</string>
     <string name="pref_key_local_alias_remotes" translatable="false">local_alias_remotes</string>
     <string name="pref_key_refresh_local_aliases" translatable="false">refresh_local_aliases</string>
     <string name="refreshing_local_alias_remotes">Refreshing local alias remotes...</string>


### PR DESCRIPTION
**Fixes**
* Crash when sharing file to rcx contains garbage data, part II
* Crash when deleting remotes
* Crash when opening changelog or license on Android Lollipop. Note that Lollipop is no longer  supported and will be removed in a future version.
* Crash when generating link
* VLC not playing audio files
* Link, Sync and Download being displayed for local remotes
* RCX not working on some 64 Bit ARM devices. This might break again in a future version.