### PR TITLE
Update Rclone to 1.61.1

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,31 +1,24 @@
 name: Android CI
 
-on:
-  push:
-    branches:
-      - 'dev'
-  pull_request:
-    branches-ignore:
-      - 'dev'
+on: [push]
 
 jobs:
-  build-all:
-
-    runs-on: ubuntu-20.04
-
+  build:
+    runs-on: 'ubuntu-22.04'
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up JDK 1.8
-      uses: actions/setup-java@v1
+    - uses: actions/checkout@v3
+    - name: Set up JDK 11
+      uses: actions/setup-java@v2
       with:
-        java-version: 1.8
-    - name: Set up Go 1.16
-      uses: actions/setup-go@v1
+        distribution: adopt
+        java-version: '11'
+    - name: Set up Go 1.19
+      uses: actions/setup-go@v3
       with:
-        go-version: 1.16
+        go-version: '1.19'
       id: go
     - name: Force NDK version
-      run: echo "y" | sudo ${ANDROID_HOME}/tools/bin/sdkmanager --install "ndk;22.1.7171670"
+      run: echo y | sudo ${ANDROID_HOME}/tools/bin/sdkmanager --install 'ndk;25.2.9519653'
     - name: Build rclone
       run: ./gradlew rclone:buildNative
     - name: Build app
@@ -59,4 +52,4 @@ jobs:
       with:
         name: universal.apk
         path: app/build/outputs/apk/oss/debug/app-oss-universal-debug.apk
-        retention-days: 14
+        retention-days: 180

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,8 +6,8 @@ android {
             keyAlias 'github_x0b'
         }
     }
-    compileSdkVersion 30
-    ndkVersion '22.1.7171670'
+    compileSdkVersion 33
+    ndkVersion '25.2.9519653'
     defaultConfig {
         applicationId 'io.github.x0b.rcx'
         minSdkVersion 21

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         maven { url 'https://jitpack.io' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.1'
+        classpath 'com.android.tools.build:gradle:7.4.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,6 @@
+#Thu Sep 23 01:27:10 PDT 2021
 distributionBase=GRADLE_USER_HOME
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.9-bin.zip
-# Warning: Update checksum when updating gradle, or Android Studio will crash!
-distributionSha256Sum=765442b8069c6bee2ea70713861c027587591c6b1df2c857a23361512560894e

--- a/rclone/build.gradle
+++ b/rclone/build.gradle
@@ -14,12 +14,12 @@
 //  - windows x86 (with NDK 21b installed)
 //
 // Prerequisits:
-//  - go 1.14 - go 1.16
+//  - go 1.19
 //  - ndk
 
 // Rclone version - any git reference (tag, branch, hash) should work
-def buildTag = 'v1.55.1'
-ext.ndkVersion = '22.1.7171670'
+def buildTag = 'v1.61.1'
+ext.ndkVersion = '25.2.9519653'
 
 //
 // DO NOT EDIT ANYTHING BELOW
@@ -100,13 +100,13 @@ task fetchRclone(type: Exec) {
     mkdir "gopath"
     environment 'GOPATH', goPath
     environment "GO111MODULE", "on"
-    commandLine 'go', 'get', '-d', repositoryRef
+    commandLine 'go', 'install', repositoryRef
 
     ignoreExitValue true
     errorOutput = new ByteArrayOutputStream()
     doLast {
         if (execResult.getExitValue() != 0) {
-            throw new GradleException("Error running go get: \n${errorOutput.toString()}")
+            throw new GradleException("Error running go install: \n${errorOutput.toString()}")
         }
     }
 }

--- a/safdav/build.gradle
+++ b/safdav/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 33
 
 
     defaultConfig {


### PR DESCRIPTION
Notably, the current state of this PR:

1. Changed the GitHub actions workflow to build on any pushes, so that my fork can build APKs with it. This needs to be reverted before actually merging into upstream.
2. Simply switched to `go install` after `go get` no longer working outside go modules, but it has the side effect of actually installing the package, which is okay in GitHub actions but not good for actual local development
3. Remmoved the gradle wrapper checksum when I updated it, which needs to be added back.